### PR TITLE
Set application icon to blatu.ico for all windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,11 +9,13 @@ Haupteinstiegspunkt der Anwendung
 
 import tkinter as tk
 from ui.main_window import MainWindow
+from utils.gui_helper import set_window_icon
 
 
 def run_app():
     """Hauptfunktion zum Starten der Anwendung"""
     root = tk.Tk()
+    set_window_icon(root)
     MainWindow(root)
     root.mainloop()
 

--- a/ui/bildschirm_anzeige_window.py
+++ b/ui/bildschirm_anzeige_window.py
@@ -10,6 +10,7 @@ import time
 
 from models.schuetze import SchuetzeModel
 from config import MAX_PASSEN_FOR_DISPLAY
+from utils.gui_helper import set_window_icon
 
 
 class BildschirmAnzeigeWindow:
@@ -20,6 +21,7 @@ class BildschirmAnzeigeWindow:
         self.schuetze_model = schuetze_model
         self.window = tk.Toplevel(parent)
         self.window.title("Bildschirmanzeige - Live-Ergebnisse")
+        set_window_icon(self.window)
         self.window.geometry("1200x800")
         
         # Scroll-Parameter (time-based for smoother movement)

--- a/ui/ergebnisse_window.py
+++ b/ui/ergebnisse_window.py
@@ -8,6 +8,7 @@ from tkinter import ttk
 
 from models.schuetze import SchuetzeModel
 from utils.pdf_generator import PDFGenerator
+from utils.gui_helper import set_window_icon
 
 
 class ErgebnisWindow:
@@ -18,6 +19,7 @@ class ErgebnisWindow:
         self.schuetze_model = schuetze_model
         self.window = tk.Toplevel(parent)
         self.window.title("Ergebnisanzeige")
+        set_window_icon(self.window)
         self.window.geometry("1000x700")
         self.create_widgets()
     

--- a/utils/gui_helper.py
+++ b/utils/gui_helper.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+GUI Helper Utilities
+"""
+import tkinter as tk
+import os
+
+def set_window_icon(window):
+    """
+    Setzt das Icon für das übergebene Fenster.
+    Versucht 'blatu.ico' im Root-Verzeichnis zu laden.
+    """
+    icon_path = "blatu.ico"
+
+    if os.path.exists(icon_path):
+        try:
+            window.iconbitmap(icon_path)
+        except tk.TclError:
+            # Kann passieren, wenn das .ico-Format beschädigt ist oder vom OS nicht unterstützt wird
+            print(f"Warnung: Icon '{icon_path}' konnte nicht geladen werden.")
+        except Exception as e:
+            print(f"Warnung: Fehler beim Laden des Icons '{icon_path}': {e}")


### PR DESCRIPTION
Added `utils/gui_helper.py` to centralize icon setting logic with error handling. Applied the icon to the main window in `main.py` and Toplevel windows in `ui/bildschirm_anzeige_window.py` and `ui/ergebnisse_window.py`. Ensures the icon is displayed on Windows and handles cases where the icon file is missing or the OS is not Windows gracefully.